### PR TITLE
Allow custom search URLs

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -4,7 +4,7 @@ import StealthPlugin from 'puppeteer-extra-plugin-stealth';
 // Add stealth plugin - this uses the actual puppeteer stealth plugin!
 chromium.use(StealthPlugin());
 
-export async function testBotDetection() {
+export async function testBotDetection(targetUrl: string = 'https://bot.sannysoft.com/') {
     console.log('🚀 Starting Playwright Stealth Test...\n');
 
     // Launch browser with stealth
@@ -26,9 +26,9 @@ export async function testBotDetection() {
     const page = await context.newPage();
 
     try {
-        // Test with bot detection site
-        console.log('📍 Testing: https://bot.sannysoft.com/');
-        await page.goto('https://bot.sannysoft.com/', { waitUntil: 'load' });
+        // Test with provided URL
+        console.log(`📍 Testing: ${targetUrl}`);
+        await page.goto(targetUrl, { waitUntil: 'load' });
 
         // Get page title
         const title = await page.title();
@@ -84,6 +84,7 @@ export async function testBotDetection() {
 
     } catch (error) {
         console.error('❌ Test failed:', error);
+        throw error;
     } finally {
         await browser.close();
     }

--- a/server.ts
+++ b/server.ts
@@ -3,9 +3,10 @@ import { testBotDetection } from './main';
 
 const app = express();
 
-app.get('/search', async (_req, res) => {
+app.get('/search', async (req, res) => {
+  const target = (req.query.url || req.query.q) as string | undefined;
   try {
-    await testBotDetection();
+    await testBotDetection(target);
     res.status(200).send('Test completed');
   } catch (error) {
     res.status(500).send('Error running test');


### PR DESCRIPTION
## Summary
- support a target URL for the search route
- propagate errors from `testBotDetection` so the API returns 500 on failure

## Testing
- `npm run build` *(fails: Cannot find module 'playwright-extra' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_688342ce9a58832d8481a4c2f6bf00d2